### PR TITLE
Fix: Explicitly install setuptools to resolve ModuleNotFoundError for…

### DIFF
--- a/warenwelt-backend/Dockerfile
+++ b/warenwelt-backend/Dockerfile
@@ -20,6 +20,7 @@ ENV PYTHONUNBUFFERED 1
 
 # Using requirements.txt
 COPY requirements.txt .
+RUN pip install --no-cache-dir setuptools
 RUN pip wheel --no-cache-dir --no-deps --wheel-dir /app/wheels -r requirements.txt
 
 


### PR DESCRIPTION
… distutils

Added `RUN pip install --no-cache-dir setuptools` to the Dockerfile before building wheels. This ensures that `setuptools` (which includes `distutils`) is available, addressing the `ModuleNotFoundError: No module named 'distutils'` that can occur, especially with newer Python versions or specific package dependencies.